### PR TITLE
Fix bug + implement bufferSubData

### DIFF
--- a/webglripper.js
+++ b/webglripper.js
@@ -584,7 +584,9 @@ class WebGLRipperWrapper {
 				LogToParent("Empty bufferData! was ", _bufferData);
 				return;
 			}
-
+			if (!(_bufferData instanceof ArrayBuffer)){
+				_bufferData = _bufferData.buffer;
+			}
 			let bufferData = [];
 
 			let vAttribData = self._GLCurrentAttrib[attr.loc];
@@ -1097,6 +1099,8 @@ class WebGLRipperWrapper {
 		let instanceCount = args[4];
 
 		LogToParent("Captured unsupported 'drawElementsInstanced' call: ", args);
+		LogToParent("Forwarding to 'drawElements'...");
+		self.hooked_drawElements(self, gl, args, oFunc);
 	}
 
 	hooked_createTexture(self, gl, args, oFunc) { // https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/createTexture

--- a/webglripper.js
+++ b/webglripper.js
@@ -216,7 +216,7 @@ class Downloader {
 	}
 } // Downloader Class
 
-let _window = parent.window;
+let _window = window;
 
 // Create config object
 _window.WEBGLRipperSettings = {

--- a/webglripper.js
+++ b/webglripper.js
@@ -724,10 +724,7 @@ class WebGLRipperWrapper {
 		                await downloadTexture(e);
 		            }
 
-		            if (++count % 5 === 0) {
-		                await pause(1000);
-		                count = 0;
-		            }
+		            await pause(500); // Pause to not overload the browser in case of big scenes
 		        }
 		    }
 

--- a/webglripper.js
+++ b/webglripper.js
@@ -476,7 +476,7 @@ class WebGLRipperWrapper {
 		let _CurrentProgram = self.HelperFunc_GetCurrentProgram(self, gl);
 		let modelMatrix = null;
 		uniformData.forEach(uniform => {
-			if (uniform.name == "modelMatrix") {
+			if (["modelMatrix", "world"].includes(uniform.name) ) {
 				var loc = gl.getUniformLocation(_CurrentProgram, uniform.name);
 				modelMatrix = gl.getUniform(_CurrentProgram, loc);
 				LogToParent("Recieved modelMatrix: ", modelMatrix);
@@ -1154,7 +1154,7 @@ class WebGLRipperWrapper {
 	}
 
 	hooked_bufferSubData(self, gl, args, oFunc) {
-		LogToParent("bufferSubData: ", args);
+		//LogToParent("bufferSubData: ", args);
 		let target = args[0];
 		let offset = args[1];
 		let srcData = args[2];


### PR DESCRIPTION
This fixes 2 bugs and adds 1 feature:
- wrong indices coming out of drawElements (oIndices is already instance of ArrayBuffer, we shouldn't take `.buffer` of it)
- wrong data coming out of UpdateAllAttributes when an offset is specified (offset was added to a view, then ignored when the buffer was extracted back from the view)
- implement bufferSubData (supports apps and libs that use the feature).